### PR TITLE
configure: avoid double start

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -22,5 +22,5 @@
 
 # If the control reaches this step, the service can be enabled and started
 
-systemctl --user enable --now mattermost.service
+systemctl --user enable mattermost.service
 systemctl --user restart mattermost.service


### PR DESCRIPTION
On first configuration, the service was restarted during just during the first setup.
As a consequence, the action was failing.