### PR TITLE
Disable healthcheck scripts

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -22,7 +22,7 @@ if ! buildah containers --format "{{.ContainerName}}" | grep -q nodebuilder-matt
 fi
 
 echo "Build static UI files with node..."
-buildah run nodebuilder-mattermost sh -c "cd /usr/src/ui && yarn install && yarn build"
+buildah run --workingdir=/usr/src/ui --env="NODE_OPTIONS=--openssl-legacy-provider" nodebuilder-mattermost sh -c "yarn install && yarn build"
 
 # Add imageroot directory to the container image
 buildah add "${container}" imageroot /imageroot

--- a/imageroot/systemd/user/mattermost-app.service
+++ b/imageroot/systemd/user/mattermost-app.service
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mattermost-app.pid \
     --env MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL} \
     --env MM_SERVICESETTINGS_LISTENADDRESS=${MM_SERVICESETTINGS_LISTENADDRESS} \
     --env MM_FILESETTINGS_DIRECTORY=${MM_FILESETTINGS_DIRECTORY} \
+    --no-healthcheck \
     ${MATTERMOST_TEAM_EDITION_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/mattermost-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP mattermost-app


### PR DESCRIPTION
Do not run bogus healthcheck script from upstream image.

Symptom: the events.log file grows too much. In `/run/user/$(id -u $MODULE_ID)/libpod/tmp/events/events.log`

    {"ID":"942ceacdfc82c0fab0c74cfa5565bb1121161507e8a70cb318783d8130e2e00a","Image":"docker.io/mattermost/mattermost-team-edition:7.4","Name":"mattermost-app","Status":"exec_died","Time":"2022-11-02T09:34:41.018125003-04:00","Type":"container","Attributes":{"execID":"baa92a82f3afc9eb6580193d7dd6e5ec8cdc1247cdae0b6e2a3baeab34925d5e"}}

In journal

    Nov 02 09:34:40 ns8n1.nethesis.it systemd[14011]: Started /usr/bin/podman healthcheck run 942ceacdfc82c0fab0c74cfa5565bb1121161507e8a70cb318783d8130e2e00a.


Error is reproducible with this command:

    podman healthcheck run mattermost-app
