### PR TITLE
Smarthost discovery for mattermost

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Start and configure a mattermost instance.
 The module uses [Mattermost Docker Image for Team Edition](https://hub.docker.com/r/mattermost/mattermost-team-edition).
 
+##Documentation
+The documenation is available at https://docs.mattermost.com/
+
+You could configure the settings by  [Environment variables](https://docs.mattermost.com/configure/environment-configuration-settings.html), the container must be restarted once the Env vars has been changed
+
 ## Install
 
 Instantiate the module with:
@@ -53,6 +58,11 @@ You can access the database of a running instance using this command:
 ```
 podman exec -ti postgres-app psql -U mattuser
 ```
+
+## Smarthost discovery
+
+Mattermost registers to the event smarthost-changed, each time you enable or disable the smarthost settings in the node, you restart mattermost.
+Before to start the containers we trigger the script discover-smarthost to find and write to an environment file `smarthost.env` the settings of the smarthost and enable the email notification.
 
 ## Uninstall
 

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import os
+
+# Connect the local Redis replica. This is necessary to consistently start
+# the service if the leader node is not reachable:
+rdb = agent.redis_connect(use_replica=True)
+smtp_settings = agent.get_smarthost_settings(rdb)
+
+
+envfile = "smarthost.env"
+
+# Do not write the env file if smarthost is not configured
+if not smtp_settings['host']:
+    try:
+        os.unlink(envfile)
+    except:
+        pass
+    sys.exit(0)
+
+# Using .tmp suffix: do not overwrite the target file until the new one is
+# saved to disk:
+with open(envfile + ".tmp", "w") as efp:
+    # TODO: adjust variable names as wanted
+    print(f"MM_EMAILSETTINGS_SENDEMAILNOTIFICATIONS={'true' if smtp_settings['enabled'] else 'false'}", file=efp)
+    print(f"MM_EMAILSETTINGS_SMTPSERVER={smtp_settings['host']}", file=efp)
+    print(f"MM_EMAILSETTINGS_SMTPPORT={smtp_settings['port']}", file=efp)
+    print(f"MM_EMAILSETTINGS_ENABLESMTPAUTH=true", file=efp)
+    print(f"MM_EMAILSETTINGS_SMTPUSERNAME={smtp_settings['username']}", file=efp)
+    print(f"MM_EMAILSETTINGS_SMTPPASSWORD={smtp_settings['password']}", file=efp)
+    if smtp_settings['encrypt_smtp'] == 'tls':
+        print(f"MM_EMAILSETTINGS_CONNECTIONSECURITY=TLS", file=efp)
+    elif smtp_settings['encrypt_smtp'] == 'starttls':
+        print(f"MM_EMAILSETTINGS_CONNECTIONSECURITY=STARTTLS", file=efp)
+    print(f"MM_EMAILSETTINGS_SKIPSERVERCERTIFICATEVERIFICATION={'true' if smtp_settings['tls_verify'] else 'false'}", file=efp)
+
+# Commit changes by replacing the existing envfile:
+os.replace(envfile + ".tmp", envfile)
+
+# NOTE: The generated envfile can be included in the service container
+#       with `podman run --env-file` or in Systemd unit with
+#       `Environment=-%S/state/smarthost.env`

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -17,12 +17,11 @@ smtp_settings = agent.get_smarthost_settings(rdb)
 
 envfile = "smarthost.env"
 
-# Do not write the env file if smarthost is not configured
+# Write the blank env file if smarthost is not configured
 if not smtp_settings['host']:
-    try:
-        os.unlink(envfile)
-    except:
-        pass
+    f = open(envfile, "w")
+    f.write("")
+    f.close
     sys.exit(0)
 
 # Using .tmp suffix: do not overwrite the target file until the new one is

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -28,7 +28,6 @@ if not smtp_settings['host']:
 # Using .tmp suffix: do not overwrite the target file until the new one is
 # saved to disk:
 with open(envfile + ".tmp", "w") as efp:
-    # TODO: adjust variable names as wanted
     print(f"MM_EMAILSETTINGS_SENDEMAILNOTIFICATIONS={'true' if smtp_settings['enabled'] else 'false'}", file=efp)
     print(f"MM_EMAILSETTINGS_SMTPSERVER={smtp_settings['host']}", file=efp)
     print(f"MM_EMAILSETTINGS_SMTPPORT={smtp_settings['port']}", file=efp)
@@ -43,7 +42,3 @@ with open(envfile + ".tmp", "w") as efp:
 
 # Commit changes by replacing the existing envfile:
 os.replace(envfile + ".tmp", envfile)
-
-# NOTE: The generated envfile can be included in the service container
-#       with `podman run --env-file` or in Systemd unit with
-#       `Environment=-%S/state/smarthost.env`

--- a/imageroot/events/smarthost-changed/10reload_services
+++ b/imageroot/events/smarthost-changed/10reload_services
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+systemctl --user restart mattermost-app.service

--- a/imageroot/systemd/user/mattermost-app.service
+++ b/imageroot/systemd/user/mattermost-app.service
@@ -6,7 +6,6 @@ After=postgres-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/smarthost.env
 ExecStartPre=runagent discover-smarthost
 WorkingDirectory=%S/state
 Restart=always
@@ -23,7 +22,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mattermost-app.pid \
     --env MM_SQLSETTINGS_DRIVERNAME=postgres \
     --env MM_SQLSETTINGS_DATASOURCE=postgres://mattuser:Nethesis,1234@127.0.0.1:5432/mattermost?sslmode=disable&connect_timeout=10 \
     --env TZ=UTC \
-    --env=MM_* \
+    --env-file=%S/state/smarthost.env \
     --env MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL} \
     --env MM_SERVICESETTINGS_LISTENADDRESS=${MM_SERVICESETTINGS_LISTENADDRESS} \
     --env MM_FILESETTINGS_DIRECTORY=${MM_FILESETTINGS_DIRECTORY} \

--- a/imageroot/systemd/user/mattermost-app.service
+++ b/imageroot/systemd/user/mattermost-app.service
@@ -6,6 +6,8 @@ After=postgres-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=-%S/state/smarthost.env
+ExecStartPre=runagent discover-smarthost
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
@@ -21,6 +23,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mattermost-app.pid \
     --env MM_SQLSETTINGS_DRIVERNAME=postgres \
     --env MM_SQLSETTINGS_DATASOURCE=postgres://mattuser:Nethesis,1234@127.0.0.1:5432/mattermost?sslmode=disable&connect_timeout=10 \
     --env TZ=UTC \
+    --env=MM_* \
     --env MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL} \
     --env MM_SERVICESETTINGS_LISTENADDRESS=${MM_SERVICESETTINGS_LISTENADDRESS} \
     --env MM_FILESETTINGS_DIRECTORY=${MM_FILESETTINGS_DIRECTORY} \


### PR DESCRIPTION
As per the topic, when the container starts,  we look before if the the smarthost is enabled on the node: 
if yes, we write the env file
if no, then we remove the env file and exit

We listen after the event smarthost-changed