### PR TITLE
Do not restart during update if service is not started

### DIFF
--- a/imageroot/update-module.d/20restart
+++ b/imageroot/update-module.d/20restart
@@ -20,4 +20,4 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-systemctl --user restart mattermost.service
+systemctl --user try-restart mattermost.service


### PR DESCRIPTION
If we try to update a service not started and mostly not configured, we have a failed container state