### PR TITLE
Add pattern validation for host name in configure-module/validate-input.json

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -20,7 +20,8 @@
         "host": {
             "type": "string",
             "description": "Host name for the application, like 'mattermost.nethserver.org'",
-            "format": "idn-hostname"
+            "format": "idn-hostname",
+            "pattern": "\\."
         },
         "lets_encrypt": {
             "type": "boolean",

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -20,7 +20,7 @@
         "host": {
             "type": "string",
             "description": "Host name for the application, like 'mattermost.nethserver.org'",
-            "format": "idn-hostname",
+            "format": "hostname",
             "pattern": "\\."
         },
         "lets_encrypt": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -35,7 +35,8 @@
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuring...",
     "email_format": "Invalid email address",
-    "domain_already_used_in_traefik":"This domain is already used in traefik"
+    "domain_already_used_in_traefik":"This domain is already used in traefik",
+    "host_pattern": "must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -36,7 +36,8 @@
     "configuring": "Configuring...",
     "email_format": "Invalid email address",
     "domain_already_used_in_traefik":"This domain is already used in traefik",
-    "host_pattern": "must be a valid fully qualified domain name"
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request adds pattern validation for the host name field in the configure-module/validate-input.json file. It ensures that the host name provided is a valid fully qualified domain name. Additionally, a validation message has been added for the host pattern.

NethServer/dev#6853