### PR TITLE
Fix active user counter regression

### DIFF
--- a/imageroot/actions/get-facts/10get_facts
+++ b/imageroot/actions/get-facts/10get_facts
@@ -13,7 +13,7 @@ import agent
 
 counter_script="""
 podman exec mattermost-app mmctl --local --json user list | \
-    jq -c '[length, map(select(.is_bot == false)) | length]'
+    jq -c '[length, map(select(.is_bot == true | not)) | length]'
 """
 
 try:


### PR DESCRIPTION
The .is_bot attribute is optional and seems present only when its value is "true".


Refs NethServer/dev#6852