### PR TITLE
Update Mattermost version to 9.11.0

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 # Terminate on error
 set -e
 
-MATTERMOST_VERSION=8.1.13
+MATTERMOST_VERSION=9.11.0
 
 # Prepare variables for later use
 images=()

--- a/imageroot/update-module.d/10database_upgrade
+++ b/imageroot/update-module.d/10database_upgrade
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# redirect the standard output  to the standard error
+exec 1>&2
+
+# check upgrade requirement : https://docs.mattermost.com/upgrade/important-upgrade-notes.html
+# fix for database upgrade from 8.1.13 to 9.11.0
+
+# test if the postgres-app is active
+if ! systemctl is-active -q --user postgres-app.service; then
+    echo "Postgres service is not active, exiting"
+    exit 0
+fi
+
+echo "Postgres service is active, we start database upgrade to 9.11.0"
+
+podman exec -i postgres-app bash -c '
+PGPASSWORD="Nethesis,1234" psql -U mattuser -d mattermost -c "
+CREATE TABLE IF NOT EXISTS retentionidsfordeletion (
+    id varchar(26) PRIMARY KEY,
+    tablename varchar(64),
+    ids varchar(26)[]
+);
+CREATE INDEX IF NOT EXISTS idx_retentionidsfordeletion_tablename ON retentionidsfordeletion (tablename);
+"'


### PR DESCRIPTION
This pull request updates the Mattermost version to 9.11.0. It also includes a database upgrade script for the same version.


https://github.com/NethServer/dev/issues/6997


mattermost 9.11.0 is a ESR ([EOL april 2025](https://endoflife.date/mattermost))
mattermost 9 [requires at least postgres 11](https://docs.mattermost.com/install/software-hardware-requirements.html), we run postgres 13 EOL [(13 Nov 2025)](https://endoflife.date/postgresql)



this where the fix database requirement comes : https://docs.mattermost.com/upgrade/important-upgrade-notes.html