### PR TITLE
Update Mattermost and Postgres image versions

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -32,7 +32,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.udp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/postgres:17.4-alpine docker.io/mattermost/mattermost-team-edition:10.5.5" \
+    --label="org.nethserver.images=docker.io/postgres:17.5-alpine docker.io/mattermost/mattermost-team-edition:10.5.5" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -32,7 +32,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.udp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/postgres:17.4-alpine docker.io/mattermost/mattermost-team-edition:10.5.2" \
+    --label="org.nethserver.images=docker.io/postgres:17.4-alpine docker.io/mattermost/mattermost-team-edition:10.5.5" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
Update the Mattermost image to version 10.5.5 and the Postgres image to version 17.5-alpine.

https://github.com/NethServer/dev/issues/7467

direct install and upgrade OK