### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.mattermost.com/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/mattermost.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-mattermost"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `ui/public/metadata.json` file to point to the NethServer documentation for Mattermost instead of the default Mattermost documentation.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL15-R15): Changed the `documentation_url` from "https://docs.mattermost.com/" to "https://docs.nethserver.org/projects/ns8/en/latest/mattermost.html".

https://github.com/NethServer/dev/issues/7399