### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/mattermost-app.service
+++ b/imageroot/systemd/user/mattermost-app.service
@@ -5,9 +5,9 @@ After=postgres-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 ExecStartPre=runagent discover-smarthost
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=90
 ExecStartPre=/bin/rm -f %t/mattermost-app.pid %t/mattermost-app.ctr-id
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mattermost-app.pid \
     --env MM_SQLSETTINGS_DRIVERNAME=postgres \
     --env MM_SQLSETTINGS_DATASOURCE=postgres://mattuser:Nethesis,1234@127.0.0.1:5432/mattermost?sslmode=disable&connect_timeout=10 \
     --env TZ=UTC \
-    --env-file=%S/state/smarthost.env \
+    --env-file=%E/state/smarthost.env \
     --env MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL} \
     --env MM_SERVICESETTINGS_LISTENADDRESS=${MM_SERVICESETTINGS_LISTENADDRESS} \
     --env MM_FILESETTINGS_DIRECTORY=${MM_FILESETTINGS_DIRECTORY} \

--- a/imageroot/systemd/user/mattermost.service
+++ b/imageroot/systemd/user/mattermost.service
@@ -10,7 +10,7 @@ Before=postgres-app.service mattermost-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-%S/state/environment
+EnvironmentFile=-%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mattermost.pid %t/mattermost.pod-id

--- a/imageroot/systemd/user/postgres-app.service
+++ b/imageroot/systemd/user/postgres-app.service
@@ -5,17 +5,17 @@ Before=mattermost-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
-ExecStartPre=/bin/mkdir -p %S/state/restore/
+ExecStartPre=/bin/mkdir -p %E/state/restore/
 ExecStartPre=/bin/rm -f %t/postgres-app.pid %t/postgres-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/postgres-app.pid \
     --cidfile %t/postgres-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/mattermost.pod-id --replace -d --name  postgres-app \
     --volume postgres-data:/var/lib/postgresql/data:Z \
-    --volume %S/state/restore/:/docker-entrypoint-initdb.d/:Z \
+    --volume %E/state/restore/:/docker-entrypoint-initdb.d/:Z \
     --env POSTGRES_USER=mattuser \
     --env POSTGRES_PASSWORD=Nethesis,1234 \
     --env POSTGRES_DB=mattermost \


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host